### PR TITLE
Defer Stormpath call to when it's actually needed

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -47,6 +47,7 @@ services:
     redeye_stormpath.default_application:
         class: Stormpath\Resource\Application
         factory: ~
+        lazy: true
 
     redeye_stormpath.id_site.url_builder:
         class: Redeye\StormpathBundle\IdSite\IdSiteUrlBuilder


### PR DESCRIPTION
Lösning för att slippa anrop till Stormpath vid instantiering av alla tjänster som dependar på `default_application`.
